### PR TITLE
Modernized code base

### DIFF
--- a/BarMagnet.xcodeproj/project.pbxproj
+++ b/BarMagnet.xcodeproj/project.pbxproj
@@ -55,8 +55,6 @@
 		23A8692518BF38FD0066E383 /* uTorrent.m in Sources */ = {isa = PBXBuildFile; fileRef = 23A8692418BF38FD0066E383 /* uTorrent.m */; };
 		23A8692818BF390A0066E383 /* VuzeRemoteUI.m in Sources */ = {isa = PBXBuildFile; fileRef = 23A8692718BF390A0066E383 /* VuzeRemoteUI.m */; };
 		23A8692C18BF39BD0066E383 /* QueryCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 23A8692B18BF39BD0066E383 /* QueryCell.m */; };
-		23A94D141A6CF11C00A255B7 /* MGSwipeButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 23A94D111A6CF11C00A255B7 /* MGSwipeButton.m */; };
-		23A94D151A6CF11C00A255B7 /* MGSwipeTableCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 23A94D131A6CF11C00A255B7 /* MGSwipeTableCell.m */; };
 		23A94F22183CD6B7004A3924 /* UINavigationControllerNoAutoRotation.m in Sources */ = {isa = PBXBuildFile; fileRef = 23A94F21183CD6B7004A3924 /* UINavigationControllerNoAutoRotation.m */; };
 		23AC2B22175D835600FCFA71 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23AC2B21175D835600FCFA71 /* UIKit.framework */; };
 		23AC2B24175D835600FCFA71 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23AC2B23175D835600FCFA71 /* Foundation.framework */; };
@@ -215,10 +213,6 @@
 		23A8692718BF390A0066E383 /* VuzeRemoteUI.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VuzeRemoteUI.m; sourceTree = "<group>"; };
 		23A8692A18BF39BD0066E383 /* QueryCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QueryCell.h; sourceTree = "<group>"; };
 		23A8692B18BF39BD0066E383 /* QueryCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QueryCell.m; sourceTree = "<group>"; };
-		23A94D101A6CF11C00A255B7 /* MGSwipeButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGSwipeButton.h; sourceTree = "<group>"; };
-		23A94D111A6CF11C00A255B7 /* MGSwipeButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGSwipeButton.m; sourceTree = "<group>"; };
-		23A94D121A6CF11C00A255B7 /* MGSwipeTableCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGSwipeTableCell.h; sourceTree = "<group>"; };
-		23A94D131A6CF11C00A255B7 /* MGSwipeTableCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGSwipeTableCell.m; sourceTree = "<group>"; };
 		23A94F20183CD6B7004A3924 /* UINavigationControllerNoAutoRotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UINavigationControllerNoAutoRotation.h; sourceTree = "<group>"; };
 		23A94F21183CD6B7004A3924 /* UINavigationControllerNoAutoRotation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UINavigationControllerNoAutoRotation.m; sourceTree = "<group>"; };
 		23AC2B1E175D835600FCFA71 /* BarMagnet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BarMagnet.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -346,18 +340,6 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		23A94D0F1A6CF11C00A255B7 /* MGSwipeTableCell */ = {
-			isa = PBXGroup;
-			children = (
-				23A94D101A6CF11C00A255B7 /* MGSwipeButton.h */,
-				23A94D111A6CF11C00A255B7 /* MGSwipeButton.m */,
-				23A94D121A6CF11C00A255B7 /* MGSwipeTableCell.h */,
-				23A94D131A6CF11C00A255B7 /* MGSwipeTableCell.m */,
-			);
-			name = MGSwipeTableCell;
-			path = MGSwipeTableCell/MGSwipeTableCell;
-			sourceTree = "<group>";
-		};
 		23AC2B15175D835600FCFA71 = {
 			isa = PBXGroup;
 			children = (
@@ -366,7 +348,6 @@
 				23A868EA18BF36DB0066E383 /* NSBencodeSerialization.xcodeproj */,
 				23F0375B18C153BD00B4D289 /* SVWebViewController */,
 				9E722FCD1F73441300023517 /* TSMessages */,
-				23A94D0F1A6CF11C00A255B7 /* MGSwipeTableCell */,
 				23AC2B27175D835600FCFA71 /* Sources */,
 				23AC2B20175D835600FCFA71 /* Frameworks */,
 				23AC2B1F175D835600FCFA71 /* Products */,
@@ -753,7 +734,7 @@
 				ORGANIZATIONNAME = "Charlotte Tortorella";
 				TargetAttributes = {
 					23AC2B1D175D835600FCFA71 = {
-						DevelopmentTeam = B52TY2Q6KY;
+                        DevelopmentTeam = B52TY2Q6KY;
 					};
 				};
 			};
@@ -859,7 +840,6 @@
 				232B0FA5178C356700A7B3DC /* TorrentDetailViewController.m in Sources */,
 				2396C92B1895EA88009BC6D3 /* UIFastProgressBar.m in Sources */,
 				23F0378318C153BD00B4D289 /* SVWebViewControllerActivitySafari.m in Sources */,
-				23A94D141A6CF11C00A255B7 /* MGSwipeButton.m in Sources */,
 				23F3E0A1189F59C700A8105A /* FileHandler.m in Sources */,
 				23A8692518BF38FD0066E383 /* uTorrent.m in Sources */,
 				23A868FB18BF38750066E383 /* NSArray+Functions.m in Sources */,
@@ -895,7 +875,6 @@
 				23A868F818BF383E0066E383 /* NSOption.m in Sources */,
 				23A8690A18BF38A90066E383 /* NSData+BEncode.m in Sources */,
 				9E7231C61F73449300023517 /* HexColors.m in Sources */,
-				23A94D151A6CF11C00A255B7 /* MGSwipeTableCell.m in Sources */,
 				23A868F718BF383E0066E383 /* NSNumber+TransferRateFormatting.m in Sources */,
 				9E7231C71F73449B00023517 /* TSBlurView.m in Sources */,
 			);
@@ -1056,7 +1035,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_RESOURCE_RULES_PATH = "$(SDKROOT)/ResourceRules.plist";
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = B52TY2Q6KY;
+                DEVELOPMENT_TEAM = B52TY2Q6KY;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Sources/Supporting Files/BarMagnet-Prefix.pch";
@@ -1092,7 +1071,7 @@
 				CODE_SIGN_RESOURCE_RULES_PATH = "$(SDKROOT)/ResourceRules.plist";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = B52TY2Q6KY;
+                DEVELOPMENT_TEAM = B52TY2Q6KY;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Sources/Supporting Files/BarMagnet-Prefix.pch";

--- a/Sources/Base.lproj/Main.storyboard
+++ b/Sources/Base.lproj/Main.storyboard
@@ -25,17 +25,9 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <searchBar key="tableHeaderView" contentMode="redraw" id="2Q8-lh-QDR">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                            <textInputTraits key="textInputTraits"/>
-                            <connections>
-                                <outlet property="delegate" destination="zWV-0Y-d6N" id="2tn-NJ-EAZ"/>
-                            </connections>
-                        </searchBar>
                         <prototypes>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="Compact" rowHeight="40" id="1uE-69-I7a" customClass="TorrentJobCheckerCell">
-                                <rect key="frame" x="0.0" y="66" width="375" height="40"/>
+                                <rect key="frame" x="0.0" y="22" width="375" height="40"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="1uE-69-I7a" id="ttq-yW-b1e">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="39.666666666666664"/>
@@ -147,20 +139,8 @@
                         </barButtonItem>
                     </navigationItem>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
-                    <connections>
-                        <outlet property="searchDisplayController" destination="OOu-W6-3b5" id="GcX-mU-5bh"/>
-                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="CCc-9c-cEk" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <searchDisplayController id="OOu-W6-3b5">
-                    <connections>
-                        <outlet property="delegate" destination="zWV-0Y-d6N" id="Xni-tn-052"/>
-                        <outlet property="searchBar" destination="2Q8-lh-QDR" id="yfN-t5-8V2"/>
-                        <outlet property="searchContentsController" destination="zWV-0Y-d6N" id="NI3-I8-izt"/>
-                        <outlet property="searchResultsDataSource" destination="zWV-0Y-d6N" id="nbm-Tg-D0D"/>
-                        <outlet property="searchResultsDelegate" destination="zWV-0Y-d6N" id="L7X-V2-I6r"/>
-                    </connections>
-                </searchDisplayController>
             </objects>
             <point key="canvasLocation" x="2078.4000000000001" y="-197.9010494752624"/>
         </scene>

--- a/Sources/Custom UI/TorrentJobCheckerCell.h
+++ b/Sources/Custom UI/TorrentJobCheckerCell.h
@@ -5,14 +5,12 @@
 //  Created by Charlotte Tortorella on 7/07/13.
 //  Copyright (c) 2013 Charlotte Tortorella. All rights reserved.
 //
-#import "MGSwipeButton.h"
-#import "MGSwipeTableCell.h"
 #import "UIFastProgressBar.h"
 #import <UIKit/UIKit.h>
 
 @class TorrentJobsTableViewController;
 
-@interface TorrentJobCheckerCell : MGSwipeTableCell
+@interface TorrentJobCheckerCell : UITableViewCell
 
 @property(nonatomic, strong) IBOutlet UILabel *name;
 @property(nonatomic, strong) IBOutlet UIFastProgressBar *percentBar;
@@ -21,6 +19,5 @@
 @property(nonatomic, strong) IBOutlet UILabel *currentStatus;
 @property(nonatomic, strong) IBOutlet UILabel *ETA;
 @property(nonatomic, strong) NSString *hashString;
-@property(nonatomic, weak) TorrentJobsTableViewController *table;
 
 @end

--- a/Sources/Custom UI/TorrentJobCheckerCell.m
+++ b/Sources/Custom UI/TorrentJobCheckerCell.m
@@ -7,13 +7,7 @@
 //
 
 #import "TorrentJobCheckerCell.h"
-#import "TorrentJobsTableViewController.h"
 
 @implementation TorrentJobCheckerCell
-
-- (void)setSwipeOffset:(CGFloat)newOffset {
-    [super setSwipeOffset:newOffset];
-    [self.table setShouldRefresh:newOffset == 0];
-}
 
 @end

--- a/Sources/View Controllers/TorrentJobsTableViewController.m
+++ b/Sources/View Controllers/TorrentJobsTableViewController.m
@@ -75,10 +75,7 @@ enum ORDER { COMPLETED = 1,
     [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(receiveUpdateHeaderNotification) name:@"update_torrent_jobs_header" object:nil];
     [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(changedClient) name:@"ChangedClient" object:nil];
 
-    if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)] &&
-        [[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){9, 0, 0}]) {
-        [self registerForPreviewingWithDelegate:self sourceView:self.tableView];
-    }
+    [self registerForPreviewingWithDelegate:self sourceView:self.tableView];
 }
 
 - (nullable UIViewController *)previewingContext:(id<UIViewControllerPreviewing>)previewingContext viewControllerForLocation:(CGPoint)location {

--- a/Sources/View Controllers/UINavigationControllerNoAutoRotation.m
+++ b/Sources/View Controllers/UINavigationControllerNoAutoRotation.m
@@ -10,6 +10,14 @@
 
 @implementation UINavigationControllerNoAutoRotation
 
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    if (@available(iOS 11.0, *)) {
+        self.navigationBar.prefersLargeTitles = YES;
+    }
+}
+
 - (BOOL)shouldAutorotate {
     return NO;
 }


### PR DESCRIPTION
Hi,

I noticed that the minimum deployment version is now iOS 9, so I've made a few changes to the code to remove deprecated code and have an updated look on iOS 11.

I switched out UISearchDisplayController for the newer UISearchController so it embeds into the UINavigationItem on iOS 11.

I've also replaced UIAlertView/UIActionSheet with UIAlertController since they're deprecated, and I've replaced MGSwipeButton with the native UITableViewRowAction, which offers full swipe to perform action on iOS 11, as well as haptic feedback.